### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,.codespellrc
+skip = .git*,.codespellrc,MRIO-full.*,MRIO-base.*,MRIO-reasoned_hermit.owl,MRIO-oldedit.*,*.obo,MRIO.owl,imports,mirror,tmp,reports,uberon_filtered.owl
 check-hidden = true
 # case sensitive etc
 ignore-regex = created_by: .*|\b(AER|CNA|TE|ND|Chromum)\b
-ignore-words-list = ser,cyclin,als,transferrin,mater
+ignore-words-list = ser,cyclin,als,transferrin,mater,te

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# case sensitive etc
+ignore-regex = created_by: .*|\b(AER|CNA|TE|ND|Chromum)\b
+ignore-words-list = ser,cyclin,als,transferrin,mater

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 An ontology for the representation of MRI acquisition and analysis.
 
 MRIO builds on the Ontology for Biomedical Investigations (OBI) to flesh out 
-the process of acquiring MR images, analyzing these images, and interpretting 
+the process of acquiring MR images, analyzing these images, and interpreting 
 the results of these analyses.
 A select set of terms from Uberon are imported to relate MRI analyses to the 
 specific brain regions.
@@ -88,7 +88,7 @@ and alignment with other neuroimaging and OBO ontologies
 (e.g. [NIDM](https://github.com/incf-nidash/nidm-terms)).
 
 The MRIO team meets biweekly via Zoom on Thursdays at 2:00pm EST to discuss ongoing development.
-External contributers are more than welcome to join these meetings to discuss new terms 
+External contributors are more than welcome to join these meetings to discuss new terms 
 or anything related to the ontology.
 To obtain a link to the biweekly MRIO discussion, please contact Alexander Bartnik at adbartni@buffalo.edu.
 

--- a/src/ontology/MRIO-edit.owl
+++ b/src/ontology/MRIO-edit.owl
@@ -172,7 +172,7 @@
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/MRIO_0000688">
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MRIO_0000342"/>
-        <IAO_0000115>A relation between some part of the MRI acquisition sequence and the setttings of an MRI machine set by a technician.</IAO_0000115>
+        <IAO_0000115>A relation between some part of the MRI acquisition sequence and the settings of an MRI machine set by a technician.</IAO_0000115>
         <rdfs:label xml:lang="en">has MRI acquisition parameter</rdfs:label>
     </owl:ObjectProperty>
     
@@ -402,7 +402,7 @@
     <!-- http://purl.obolibrary.org/obo/MRIO_0000345 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MRIO_0000345">
-        <IAO_0000115>A T1 weighted image data set where gadolidium contrast agent has been administered to the participant before image acquistion.</IAO_0000115>
+        <IAO_0000115>A T1 weighted image data set where gadolidium contrast agent has been administered to the participant before image acquisition.</IAO_0000115>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <IAO_0000117>https://orcid.org/0000-0001-9990-8331 &quot;Alexander D. Diehl&quot;</IAO_0000117>
         <IAO_0000117>https://orcid.org/0000-0002-2104-0568 &quot;Lucas M. Serra&quot;</IAO_0000117>
@@ -480,7 +480,7 @@
     <!-- http://purl.obolibrary.org/obo/MRIO_0000351 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MRIO_0000351">
-        <IAO_0000115>An magnetic resonance image data set in which the contrast emphasizes density of protons, supressing T1 and T2 effects</IAO_0000115>
+        <IAO_0000115>An magnetic resonance image data set in which the contrast emphasizes density of protons, suppressing T1 and T2 effects</IAO_0000115>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <IAO_0000117>https://orcid.org/0000-0001-9990-8331 &quot;Alexander D. Diehl&quot;</IAO_0000117>
         <IAO_0000117>https://orcid.org/0000-0002-2104-0568 &quot;Lucas M. Serra&quot;</IAO_0000117>
@@ -1103,7 +1103,7 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0003343"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <IAO_0000115>An MRI acquisition sequence that acheives T1 weighting using gradient echo instead of spin echo.</IAO_0000115>
+        <IAO_0000115>An MRI acquisition sequence that achieves T1 weighting using gradient echo instead of spin echo.</IAO_0000115>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <IAO_0000117>https://orcid.org/0000-0002-2104-0568 &quot;Lucas M. Serra&quot;</IAO_0000117>
         <rdfs:label xml:lang="en">T1 GRE sequence</rdfs:label>
@@ -1175,7 +1175,7 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MRIO_0000661"/>
             </owl:Restriction>
         </owl:disjointWith>
-        <IAO_0000115>An MRI acquisition sequence that acheives T2 weighting using gradient echo instead of spin echo.</IAO_0000115>
+        <IAO_0000115>An MRI acquisition sequence that achieves T2 weighting using gradient echo instead of spin echo.</IAO_0000115>
         <IAO_0000116>Needs GRE sequence.</IAO_0000116>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <IAO_0000117>https://orcid.org/0000-0002-2104-0568 &quot;Lucas M. Serra&quot;</IAO_0000117>
@@ -2125,7 +2125,7 @@ The values often belong to a group of pixels or voxels that share the same chara
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MRIO_0000649"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <IAO_0000115>A structural connectivity matrix where each element respresents the number of white matter streamlines still connecting two brain regions when accounting for focal lesion damage, normalized for the NeMo healthy control tractogram set.</IAO_0000115>
+        <IAO_0000115>A structural connectivity matrix where each element represents the number of white matter streamlines still connecting two brain regions when accounting for focal lesion damage, normalized for the NeMo healthy control tractogram set.</IAO_0000115>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <rdfs:label xml:lang="en">nConMat matrix</rdfs:label>
     </owl:Class>
@@ -2466,7 +2466,7 @@ The values often belong to a group of pixels or voxels that share the same chara
     <!-- http://purl.obolibrary.org/obo/MRIO_0000635 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MRIO_0000635">
-        <IAO_0000115>A type of magnetic resonance image data set collected using at least three diffusion gradients of some factor &quot;b,&quot; which is a function of the amplitude, duration, and interval of the gradiants.</IAO_0000115>
+        <IAO_0000115>A type of magnetic resonance image data set collected using at least three diffusion gradients of some factor &quot;b,&quot; which is a function of the amplitude, duration, and interval of the gradients.</IAO_0000115>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <IAO_0000117>https://orcid.org/0000-0001-9990-8331 &quot;Alexander D. Diehl&quot;</IAO_0000117>
         <IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/OBI_0003335"/>
@@ -2640,7 +2640,7 @@ The values often belong to a group of pixels or voxels that share the same chara
     <!-- http://purl.obolibrary.org/obo/MRIO_0000648 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MRIO_0000648">
-        <IAO_0000115>A brain atlas consisting of weighted values that respresent the probability that a voxel X is part of some brain component Y, typically derived from multiple image data sets.</IAO_0000115>
+        <IAO_0000115>A brain atlas consisting of weighted values that represent the probability that a voxel X is part of some brain component Y, typically derived from multiple image data sets.</IAO_0000115>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <IAO_0000117>https://orcid.org/0000-0001-9990-8331 &quot;Alexander D. Diehl&quot;</IAO_0000117>
         <IAO_0000117>https://orcid.org/0000-0002-9821-4132 &quot;Mackenzie T. Smith&quot;</IAO_0000117>
@@ -2965,7 +2965,7 @@ The values often belong to a group of pixels or voxels that share the same chara
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MRIO_0000651">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MRIO_0000421"/>
-        <IAO_0000115>A funtional MRI data set analysis software suite of preconfigured pipelines for analysis fMRI data and estimating functional connectomics.</IAO_0000115>
+        <IAO_0000115>A functional MRI data set analysis software suite of preconfigured pipelines for analysis fMRI data and estimating functional connectomics.</IAO_0000115>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <IAO_0000119>https://doi.org/10.3389/conf.fninf.2013.09.00042</IAO_0000119>
         <rdfs:comment>The Configurable Pipeline for the Analysis of Connectomes (C-PAC) is a configurable, open-source, Nipype-based, automated processing pipeline for resting state functional MRI (R-fMRI) data, for use by both novice and expert users.</rdfs:comment>
@@ -3111,7 +3111,7 @@ The values often belong to a group of pixels or voxels that share the same chara
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0003344"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <IAO_0000115>FreeSurfer stream to derive surface labels and volumes from an invidual at only one timepoint.</IAO_0000115>
+        <IAO_0000115>FreeSurfer stream to derive surface labels and volumes from an individual at only one timepoint.</IAO_0000115>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <rdfs:label xml:lang="en">FreeSurfer cross-sectional analysis</rdfs:label>
     </owl:Class>
@@ -3201,7 +3201,7 @@ The values often belong to a group of pixels or voxels that share the same chara
         <IAO_0000115>A brain volumetric analysis tool that estimates the percent brain volume change in an individual between two timepoints using baseline and follow-up T1w MRI.</IAO_0000115>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <IAO_0000119>Smith, Stephen M.; De Stefano, Nicola; Jenkinson, Mark; Matthews, Paul M. Normalized Accurate Measurement of Longitudinal Brain Change, Journal of Computer Assisted Tomography: May 2001 - Volume 25 - Issue 3 - p 466-475</IAO_0000119>
-        <rdfs:comment>Siena estimates percentage brain volume change (PBVC) betweem two input images, taken of the same subject, at different points in time. It calls a series of FSL programs to strip the non-brain tissue from the two images, register the two brains (under the constraint that the skulls are used to hold the scaling constant during the registration) and analyse the brain change between the two time points. It is also possible to project the voxelwise atrophy measures into standard space in a way that allows for multi-subject voxelwise statistical testing.</rdfs:comment>
+        <rdfs:comment>Siena estimates percentage brain volume change (PBVC) between two input images, taken of the same subject, at different points in time. It calls a series of FSL programs to strip the non-brain tissue from the two images, register the two brains (under the constraint that the skulls are used to hold the scaling constant during the registration) and analyse the brain change between the two time points. It is also possible to project the voxelwise atrophy measures into standard space in a way that allows for multi-subject voxelwise statistical testing.</rdfs:comment>
         <rdfs:label xml:lang="en">SIENA analysis</rdfs:label>
     </owl:Class>
     
@@ -3482,7 +3482,7 @@ The values often belong to a group of pixels or voxels that share the same chara
             </owl:Restriction>
         </rdfs:subClassOf>
         <IAO_0000115>An MRI acquisition sequence that uses diffusion gradients to create contrast in the image corresponding to the Brownian motion of the tissue in the examined voxel.</IAO_0000115>
-        <IAO_0000116>Add difussion gradient as parameter.</IAO_0000116>
+        <IAO_0000116>Add diffusion gradient as parameter.</IAO_0000116>
         <IAO_0000117>https://orcid.org/0000-0001-9676-7377 &quot;Alexander D. Bartnik&quot;</IAO_0000117>
         <IAO_0000117>https://orcid.org/0000-0001-9990-8331 &quot;Alexander D. Diehl&quot;</IAO_0000117>
         <oboInOwl:hasRelatedSynonym>NCIT:C111116</oboInOwl:hasRelatedSynonym>
@@ -5487,7 +5487,7 @@ The values often belong to a group of pixels or voxels that share the same chara
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MRIO_1000033">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MRIO_1000003"/>
-        <IAO_0000115>A type of functional magnetic resonance imaging (fMRI) sequence protocol in which the participant is given specific tasks or stimuli that alternate between structured blocks and randomized or semi-randomized order seperated by rest periods during the imaging acquisition.</IAO_0000115>
+        <IAO_0000115>A type of functional magnetic resonance imaging (fMRI) sequence protocol in which the participant is given specific tasks or stimuli that alternate between structured blocks and randomized or semi-randomized order separated by rest periods during the imaging acquisition.</IAO_0000115>
         <terms:creator rdf:resource="https://orcid.org/0009-0004-2155-902X"/>
         <terms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-07-31T21:38:59Z</terms:date>
         <oboInOwl:hasExactSynonym>mixed event-related/block design fMRI sequence protocol</oboInOwl:hasExactSynonym>

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -450,7 +450,7 @@ $(MIRRORDIR)/%.owl: mirror-% | $(MIRRORDIR)
 
 else # MIR=false
 $(MIRRORDIR)/%.owl:
-	@echo "Not refreshing $@ because the mirrorring pipeline is disabled (MIR=$(MIR))."
+	@echo "Not refreshing $@ because the mirroring pipeline is disabled (MIR=$(MIR))."
 endif
 
 

--- a/src/ontology/mrio-template.tsv
+++ b/src/ontology/mrio-template.tsv
@@ -226,7 +226,7 @@ raw image data set	image data set
 reagent	
 reconstructed MR image data set	
 regional functional connectome analysis	functional connectome analysis
-repitition time	MRI machine parameter
+repetition time	MRI machine parameter
 right auditory cortex	
 right dorsal thalamic volume measurement datum	'is about' some 'right dorsal thalamus'|dorsal thalamic volume measurement datum
 right dorsal thalamus	

--- a/src/ontology/target/MRIO/CONTRIBUTING.md
+++ b/src/ontology/target/MRIO/CONTRIBUTING.md
@@ -68,11 +68,11 @@ For how to write a good term request, please read the [best practices carefully]
 
 ### How to add a new term
 
-If you have never editted this ontology before, first follow a [general tutorial](https://oboacademy.github.io/obook/lesson/contributing-to-obo-ontologies)
+If you have never edited this ontology before, first follow a [general tutorial](https://oboacademy.github.io/obook/lesson/contributing-to-obo-ontologies)
 
 **Process**:
 
-1. Clone the repository (In case you are not an offical team member, create a fork first)
+1. Clone the repository (In case you are not an official team member, create a fork first)
 1. Create new branch in git, for example `git checkout -b issue123`
 1. Open src/ontology/MRIO-edit.owl in your favourite editor, i.e. [Protege](https://protege.stanford.edu/). **Careful:** double check you are editing the correct file. There are many ontology files in this repository, but only one _editors file_!
 1. Perform your edit and save your changes

--- a/src/ontology/target/MRIO/src/ontology/Makefile
+++ b/src/ontology/target/MRIO/src/ontology/Makefile
@@ -450,7 +450,7 @@ $(MIRRORDIR)/%.owl: mirror-% | $(MIRRORDIR)
 
 else # MIR=false
 $(MIRRORDIR)/%.owl:
-	@echo "Not refreshing $@ because the mirrorring pipeline is disabled (MIR=$(MIR))."
+	@echo "Not refreshing $@ because the mirroring pipeline is disabled (MIR=$(MIR))."
 endif
 
 

--- a/src/ontology/target/MRIO/src/ontology/README-editors.md
+++ b/src/ontology/target/MRIO/src/ontology/README-editors.md
@@ -6,7 +6,7 @@ For more details on ontology management, please see the
 [OBO Academy Tutorials](https://oboacademy.github.io/obook/), the
 [OBO tutorial](https://github.com/jamesaoverton/obo-tutorial) or the [Gene Ontology Editors Tutorial](https://go-protege-tutorial.readthedocs.io/en/latest/)
 
-This documentation has been superceded by the ODK automatic documentation, which you can
+This documentation has been superseded by the ODK automatic documentation, which you can
 activate by adding:
 
 ```

--- a/src/ontology/target/MRIO/src/scripts/update_repo.sh
+++ b/src/ontology/target/MRIO/src/scripts/update_repo.sh
@@ -1,5 +1,5 @@
 echo "This (experimental) update script will create a new repo according to your config file. It will:" 
-echo "(1) overwrite your repositories Makefile, ODK sparql queries (your custom queries wont be touched) and docker wrapper (run.sh)."
+echo "(1) overwrite your repositories Makefile, ODK sparql queries (your custom queries won't be touched) and docker wrapper (run.sh)."
 echo "(2) and add missing files, if any."
 
 set -e

--- a/src/ontology/target/MRIO/src/sparql/README.md
+++ b/src/ontology/target/MRIO/src/sparql/README.md
@@ -2,7 +2,7 @@
 
 [SPARQL](https://www.w3.org/TR/rdf-sparql-query/) is a W3C standard
 query language for RDF. This directory contains useful SPARQL queries
-for perfoming over the ontology.
+for performing over the ontology.
 
 SPARQL can be executed on a triplestore or directly on any OWL
 file. The queries here are all executed on either MRIO-edit.obo or

--- a/src/scripts/assign_analyses.py
+++ b/src/scripts/assign_analyses.py
@@ -18,7 +18,7 @@ def find_analyses(seq_labels): #input should be list of strings with identifying
     #list of image IRIs
     args = list([])
 
-    #contruction of 1st query, linking sequences to images
+    #construction of 1st query, linking sequences to images
     str_a = "PREFIX owl: <http://www.w3.org/2002/07/owl#> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> PREFIX root: <http://purl.obolibrary.org/obo/MRIO_0000341> PREFIX output: <http://purl.obolibrary.org/obo/OBI_0000299> SELECT DISTINCT ?seq ?seq_label ?image ?image_label WHERE { ?image rdfs:subClassOf* root: . ?image rdfs:label ?image_label . ?seq rdfs:label ?seq_label . ?seq rdfs:subClassOf [ a owl:Restriction; owl:onProperty output:; owl:someValuesFrom ?image ]. "
     str_c = "} order by ?image"
     for x in range(len(seq_labels)):

--- a/src/scripts/update_repo.sh
+++ b/src/scripts/update_repo.sh
@@ -1,5 +1,5 @@
 echo "This (experimental) update script will create a new repo according to your config file. It will:" 
-echo "(1) overwrite your repositories Makefile, ODK sparql queries (your custom queries wont be touched) and docker wrapper (run.sh)."
+echo "(1) overwrite your repositories Makefile, ODK sparql queries (your custom queries won't be touched) and docker wrapper (run.sh)."
 echo "(2) and add missing files, if any."
 
 set -e

--- a/src/sparql/README.md
+++ b/src/sparql/README.md
@@ -2,7 +2,7 @@
 
 [SPARQL](https://www.w3.org/TR/rdf-sparql-query/) is a W3C standard
 query language for RDF. This directory contains useful SPARQL queries
-for perfoming over the ontology.
+for performing over the ontology.
 
 SPARQL can be executed on a triplestore or directly on any OWL
 file. The queries here are all executed on either MRIO-edit.obo or


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

Got inspired by 
- https://github.com/Buffalo-Ontology-Group/MRI_Ontology/pull/25#issuecomment-3469770147

but extended not only to src/ontology/MRIO-edit.owl but everything I have not excluded. See the skips I added.

With this, CI would verify that there is no typos added into any of not skipped files.